### PR TITLE
Invidiually-Unique Pokémon Colors

### DIFF
--- a/include/decompress.h
+++ b/include/decompress.h
@@ -13,6 +13,7 @@ void LoadCompressedSpriteSheetOverrideBuffer(const struct CompressedSpriteSheet 
 bool8 LoadCompressedSpriteSheetUsingHeap(const struct CompressedSpriteSheet* src);
 
 void LoadCompressedSpritePalette(const struct CompressedSpritePalette *src);
+void LoadHueShiftedMonSpritePalette(const struct CompressedSpritePalette *src, u32 personality);
 void LoadCompressedSpritePaletteOverrideBuffer(const struct CompressedSpritePalette *a, void *buffer);
 bool8 LoadCompressedSpritePaletteUsingHeap(const struct CompressedSpritePalette *src);
 

--- a/include/palette.h
+++ b/include/palette.h
@@ -53,6 +53,8 @@ extern u16 gPlttBufferUnfaded[];
 extern u16 gPlttBufferFaded[];
 
 void LoadCompressedPalette(const u32 *, u16, u16);
+void HueShiftMonPalette(u16*, u32);
+void LoadHueShiftedMonPalette(const u32 *, u16, u16, u32);
 void LoadPalette(const void *, u16, u16);
 void FillPalette(u16, u16, u16);
 void TransferPlttBuffer(void);

--- a/src/battle_anim_mons.c
+++ b/src/battle_anim_mons.c
@@ -2073,7 +2073,7 @@ u8 CreateAdditionalMonSpriteForMoveAnim(u16 species, bool8 isBackpic, u8 id, s16
         gMonSpritesGfxPtr->buffer = AllocZeroed(0x2000);
     if (!isBackpic)
     {
-        LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, trainerId, personality), (palette * 0x10) + 0x100, 0x20);
+        LoadHueShiftedMonPalette(GetMonSpritePalFromSpeciesAndPersonality(species, trainerId, personality), (palette * 0x10) + 0x100, 0x20, personality);
         LoadSpecialPokePic(&gMonFrontPicTable[species],
                            gMonSpritesGfxPtr->buffer,
                            species,
@@ -2082,7 +2082,7 @@ u8 CreateAdditionalMonSpriteForMoveAnim(u16 species, bool8 isBackpic, u8 id, s16
     }
     else
     {
-        LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, trainerId, personality), (palette * 0x10) + 0x100, 0x20);
+        LoadHueShiftedMonPalette(GetMonSpritePalFromSpeciesAndPersonality(species, trainerId, personality), (palette * 0x10) + 0x100, 0x20, personality);
         LoadSpecialPokePic(&gMonBackPicTable[species],
                            gMonSpritesGfxPtr->buffer,
                            species,

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -615,6 +615,7 @@ static void BattleLoadMonSpriteGfx(struct Pokemon *mon, u32 battlerId, bool32 op
     {
         paletteOffset = 0x100 + battlerId * 16;
         LZDecompressWram(lzPaletteData, gBattleStruct->castformPalette[0]);
+        HueShiftMonPalette((u16*) gBattleStruct->castformPalette[0], currentPersonality);
         LoadPalette(gBattleStruct->castformPalette[gBattleMonForms[battlerId]], paletteOffset, 0x20);
     }
 

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -605,6 +605,9 @@ static void BattleLoadMonSpriteGfx(struct Pokemon *mon, u32 battlerId, bool32 op
         lzPaletteData = GetMonSpritePalFromSpeciesAndPersonality(species, otId, monsPersonality);
 
     LZDecompressWram(lzPaletteData, gDecompressionBuffer);
+
+    HueShiftMonPalette((u16*) gDecompressionBuffer, currentPersonality);
+
     LoadPalette(gDecompressionBuffer, paletteOffset, 0x20);
     LoadPalette(gDecompressionBuffer, 0x80 + battlerId * 16, 0x20);
 
@@ -925,6 +928,7 @@ void HandleSpeciesGfxDataChange(u8 battlerAtk, u8 battlerDef, bool8 notTransform
         paletteOffset = 0x100 + battlerAtk * 16;
         lzPaletteData = GetMonSpritePalFromSpeciesAndPersonality(targetSpecies, otId, personalityValue);
         LZDecompressWram(lzPaletteData, gDecompressionBuffer);
+        HueShiftMonPalette((u16*) gDecompressionBuffer, personalityValue);
         LoadPalette(gDecompressionBuffer, paletteOffset, 32);
 
         if (targetSpecies == SPECIES_CASTFORM || targetSpecies == SPECIES_CHERRIM)

--- a/src/contest.c
+++ b/src/contest.c
@@ -3123,7 +3123,7 @@ static u8 CreateContestantSprite(u16 species, u32 otId, u32 personality, u32 ind
 
     HandleLoadSpecialPokePic(&gMonBackPicTable[species], gMonSpritesGfxPtr->sprites.ptr[0], species, personality);
 
-    LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, otId, personality), 0x120, 0x20);
+    LoadHueShiftedMonPalette(GetMonSpritePalFromSpeciesAndPersonality(species, otId, personality), 0x120, 0x20, personality);
     SetMultiuseSpriteTemplateToPokemon(species, 0);
 
     spriteId = CreateSprite(&gMultiuseSpriteTemplate, 0x70, GetBattlerSpriteFinal_Y(2, species, FALSE), 30);

--- a/src/contest_painting.c
+++ b/src/contest_painting.c
@@ -365,6 +365,7 @@ static void InitContestMonPixels(u16 species, u8 whichSprite)
 {
     const void *pal = GetMonSpritePalFromSpeciesAndPersonality(species, gContestPaintingWinner->trainerId, gContestPaintingWinner->personality);
     LZDecompressVram(pal, gContestPaintingMonPalette);
+    HueShiftMonPalette(gContestPaintingMonPalette, gContestPaintingWinner->personality);
     if (whichSprite == 0)
     {
         HandleLoadSpecialPokePic(

--- a/src/decompress.c
+++ b/src/decompress.c
@@ -3,6 +3,7 @@
 #include "data.h"
 #include "decompress.h"
 #include "pokemon.h"
+#include "palette.h"
 #include "text.h"
 
 EWRAM_DATA ALIGNED(4) u8 gDecompressionBuffer[0x4000] = {0};
@@ -44,6 +45,20 @@ void LoadCompressedSpritePalette(const struct CompressedSpritePalette *src)
     struct SpritePalette dest;
 
     LZ77UnCompWram(src->data, gDecompressionBuffer);
+
+    dest.data = (void*) gDecompressionBuffer;
+    dest.tag = src->tag;
+    LoadSpritePalette(&dest);
+}
+
+void LoadHueShiftedMonSpritePalette(const struct CompressedSpritePalette *src, u32 personality)
+{
+    struct SpritePalette dest;
+
+    LZ77UnCompWram(src->data, gDecompressionBuffer);
+
+    HueShiftMonPalette((u16*) gDecompressionBuffer, personality);
+
     dest.data = (void*) gDecompressionBuffer;
     dest.tag = src->tag;
     LoadSpritePalette(&dest);

--- a/src/egg_hatch.c
+++ b/src/egg_hatch.c
@@ -437,7 +437,7 @@ static u8 EggHatchCreateMonSprite(u8 a0, u8 switchID, u8 pokeID, u16* speciesLoc
             HandleLoadSpecialPokePic(&gMonFrontPicTable[species],
                                      gMonSpritesGfxPtr->sprites.ptr[(a0 * 2) + 1],
                                      species, pid);
-            LoadCompressedSpritePalette(GetMonSpritePalStruct(mon));
+            LoadHueShiftedMonSpritePalette(GetMonSpritePalStruct(mon), pid);
             *speciesLoc = species;
         }
         break;

--- a/src/evolution_scene.c
+++ b/src/evolution_scene.c
@@ -262,7 +262,7 @@ void EvolutionScene(struct Pokemon* mon, u16 postEvoSpecies, bool8 canStopEvo, u
                                 currSpecies,
                                 personality);
     pokePal = GetMonSpritePalStructFromOtIdPersonality(currSpecies, trainerId, personality);
-    LoadCompressedPalette(pokePal->data, 0x110, 0x20);
+    LoadHueShiftedMonPalette(pokePal->data, 0x110, 0x20, personality);
 
     SetMultiuseSpriteTemplateToPokemon(currSpecies, 1);
     gMultiuseSpriteTemplate.affineAnims = gDummySpriteAffineAnimTable;
@@ -277,7 +277,7 @@ void EvolutionScene(struct Pokemon* mon, u16 postEvoSpecies, bool8 canStopEvo, u
                                 postEvoSpecies,
                                 personality);
     pokePal = GetMonSpritePalStructFromOtIdPersonality(postEvoSpecies, trainerId, personality);
-    LoadCompressedPalette(pokePal->data, 0x120, 0x20);
+    LoadHueShiftedMonPalette(pokePal->data, 0x120, 0x20, personality);
 
     SetMultiuseSpriteTemplateToPokemon(postEvoSpecies, 3);
     gMultiuseSpriteTemplate.affineAnims = gDummySpriteAffineAnimTable;
@@ -355,7 +355,7 @@ static void CB2_EvolutionSceneLoadGraphics(void)
                                 personality);
     pokePal = GetMonSpritePalStructFromOtIdPersonality(postEvoSpecies, trainerId, personality);
 
-    LoadCompressedPalette(pokePal->data, 0x120, 0x20);
+    LoadHueShiftedMonPalette(pokePal->data, 0x120, 0x20, personality);
 
     SetMultiuseSpriteTemplateToPokemon(postEvoSpecies, 3);
     gMultiuseSpriteTemplate.affineAnims = gDummySpriteAffineAnimTable;
@@ -426,7 +426,7 @@ static void CB2_TradeEvolutionSceneLoadGraphics(void)
                                         postEvoSpecies,
                                         personality);
             pokePal = GetMonSpritePalStructFromOtIdPersonality(postEvoSpecies, trainerId, personality);
-            LoadCompressedPalette(pokePal->data, 0x120, 0x20);
+            LoadHueShiftedMonPalette(pokePal->data, 0x120, 0x20, personality);
             gMain.state++;
         }
         break;
@@ -491,7 +491,7 @@ void TradeEvolutionScene(struct Pokemon* mon, u16 postEvoSpecies, u8 preEvoSprit
                                 personality);
 
     pokePal = GetMonSpritePalStructFromOtIdPersonality(postEvoSpecies, trainerId, personality);
-    LoadCompressedPalette(pokePal->data, 0x120, 0x20);
+    LoadHueShiftedMonPalette(pokePal->data, 0x120, 0x20, personality);
 
     SetMultiuseSpriteTemplateToPokemon(postEvoSpecies, 1);
     gMultiuseSpriteTemplate.affineAnims = gDummySpriteAffineAnimTable;

--- a/src/menu_specialized.c
+++ b/src/menu_specialized.c
@@ -1055,6 +1055,7 @@ void GetConditionMenuMonGfx(void *tilesDst, void *palDst, u16 boxId, u16 monId, 
 
         LoadSpecialPokePic(&gMonFrontPicTable[species], tilesDst, species, personality, TRUE);
         LZ77UnCompWram(GetMonSpritePalFromSpeciesAndPersonality(species, trainerId, personality), palDst);
+        HueShiftMonPalette((u16*) palDst, personality);
     }
 }
 

--- a/src/palette.c
+++ b/src/palette.c
@@ -86,6 +86,159 @@ void LoadCompressedPalette(const u32 *src, u16 offset, u16 size)
     CpuCopy16(gPaletteDecompressionBuffer, gPlttBufferFaded + offset, size);
 }
 
+static const u16 sCosTable[] = {
+    0x0400,
+    0x03FF,
+    0x03FF,
+    0x03FF,
+    0x03FE,
+    0x03FE,
+    0x03FD,
+    0x03FC,
+    0x03FB,
+    0x03FA,
+    0x03F9,
+    0x03F8,
+    0x03F6,
+    0x03F5,
+    0x03F3,
+    0x03F1,
+    0x03EF,
+    0x03ED,
+    0x03EB,
+    0x03E8,
+    0x03E6,
+    0x03E3,
+    0x03E0,
+    0x03DD,
+    0x03DA,
+    0x03D7,
+    0x03D4,
+    0x03D1,
+    0x03CD,
+    0x03C9,
+    0x03C6,
+    0x03C2
+};
+
+static const u16 sSinTable[] = {
+    0x0000,
+    0x000B,
+    0x0017,
+    0x0022,
+    0x002E,
+    0x0039,
+    0x0045,
+    0x0050,
+    0x005C,
+    0x0067,
+    0x0073,
+    0x007E,
+    0x0089,
+    0x0095,
+    0x00A0,
+    0x00AC,
+    0x00B7,
+    0x00C2,
+    0x00CE,
+    0x00D9,
+    0x00E4,
+    0x00EF,
+    0x00FB,
+    0x0106,
+    0x0111,
+    0x011C,
+    0x0127,
+    0x0132,
+    0x013D,
+    0x0148,
+    0x0153,
+    0x015E
+};
+
+//Chosen to provide the most amount of precision without overflowing in our use case
+typedef s32 fixed;
+#define FIX_SHIFT 10
+
+#define ONE        (fixed) (1  << FIX_SHIFT)
+#define THREE      (fixed) (3  << FIX_SHIFT)
+#define THIRTY_TWO (fixed) (32 << FIX_SHIFT)
+#define ONE_HALF   (fixed) (1  << (FIX_SHIFT-1))
+#define ONE_THIRD  (fixed) (0x155)
+#define TWO_THIRDS (fixed) (0x2AA)
+#define SQRT_1_3   (fixed) (0x24F)
+
+///Multiply two fixed point values
+static inline fixed FxMul(fixed fa, fixed fb) { return (fa*fb)>>FIX_SHIFT; }
+
+///Take a fixed point value and round it, clamp to 0 or 31, then shift down to integer
+static inline s32 RoundClampShift(fixed v) {
+    v += ONE_HALF;
+    if (v < 0)           return 0;
+    if (v >= THIRTY_TWO) return 31;
+    return v >> FIX_SHIFT;
+}
+
+/***
+ * Performs a hue shift on the colors in a given palette. Index must be from 0 to 63.
+ * Values 0-31 shift right, while values 32-63 shift left (but 32 is treated as 0, 33 as 1, etc.).
+ ***/
+void HueShiftMonPalette(u16* colors, u32 personality) {
+    //Use third personality byte to determine color;
+    //Limit the index to valid bounds
+    u32 index = (personality >> 16) & (64-1);
+
+    //sCosTable and sSinTable are two tables for precalculated cosine values, one after other, each with 32
+    //elements of two bytes. The values are represented in fixed point, and the table doesn't go very far around the
+    //circle (currently represent about +/-20 degrees).
+    //The index into the table is treated a little strangely. an index of 0 corresponds to cos(0) and sin(0).
+    //values of index after 32 are treated like -(index-32). for cosine, because cos(x) == cos(-x), I can just
+    //chop off bits after the first 5 and index into the table. For sine, sin(-x) == -sin(x), so I flip the sign of the
+    //value in the table at (index-32). This is all done to save space.
+    fixed cosA = sCosTable[index & 31],
+          sinA = index >= 32 ? -(fixed)(sSinTable[index-32]) : sSinTable[index];
+
+    //The following code performs an approximate hue shift on each color in the palette, taken from this post on stack
+    //overflow, optimized to work with this fixed point stuff: https://stackoverflow.com/a/8510751/963007
+    fixed val1 = ONE_THIRD + FxMul(cosA, TWO_THIRDS);
+    fixed val2 = FxMul(ONE - cosA, ONE_THIRD) - FxMul(SQRT_1_3, sinA);
+    fixed val3 = FxMul(ONE - cosA, ONE_THIRD) + FxMul(SQRT_1_3, sinA);
+
+    u8 i;
+    u16 color;
+    fixed r, g, b;
+    s32 rx, gx, bx;
+
+    for (i = 1; i < 16; i++) { //Skip past first color, which is transparency
+        color = colors[i];
+
+        //Unpack the color
+        r     = (color & 0x1F) << FIX_SHIFT;
+        color = color >> 5;
+        g     = (color & 0x1F) << FIX_SHIFT;
+        color = color >> 5;
+        b     = (color & 0x1F) << FIX_SHIFT;
+
+        //Hue shift, clamping at the max component value (31)
+        rx = RoundClampShift(FxMul(r, val1) + FxMul(g, val2) + FxMul(b, val3));
+        gx = RoundClampShift(FxMul(r, val3) + FxMul(g, val1) + FxMul(b, val2));
+        bx = RoundClampShift(FxMul(r, val2) + FxMul(g, val3) + FxMul(b, val1));
+
+        //Pack the color
+        colors[i] = rx | (gx << 5) | (bx << 10);
+    }
+}
+
+void LoadHueShiftedMonPalette(const u32 *src, u16 offset, u16 size, u32 personality)
+{
+    LZDecompressWram(src, gPaletteDecompressionBuffer);
+
+    HueShiftMonPalette((u16*) gPaletteDecompressionBuffer, personality);
+
+    CpuCopy16(gPaletteDecompressionBuffer, gPlttBufferUnfaded + offset, size);
+    CpuCopy16(gPaletteDecompressionBuffer, gPlttBufferFaded + offset, size);
+}
+
 void LoadPalette(const void *src, u16 offset, u16 size)
 {
     CpuCopy16(src, gPlttBufferUnfaded + offset, size);

--- a/src/pokeblock_feed.c
+++ b/src/pokeblock_feed.c
@@ -741,7 +741,7 @@ static bool8 LoadMonAndSceneGfx(struct Pokemon *mon)
         trainerId = GetMonData(mon, MON_DATA_OT_ID);
         palette = GetMonSpritePalStructFromOtIdPersonality(species, trainerId, personality);
 
-        LoadCompressedSpritePalette(palette);
+        LoadHueShiftedMonSpritePalette(palette, personality);
         SetMultiuseSpriteTemplateToPokemon(palette->tag, 1);
         sPokeblockFeed->loadGfxState++;
         break;

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -4411,7 +4411,7 @@ static void Task_ExitCaughtMonPage(u8 taskId)
         personality = ((u16)gTasks[taskId].tPersonalityHi << 16) | (u16)gTasks[taskId].tPersonalityLo;
         paletteNum = gSprites[gTasks[taskId].tMonSpriteId].oam.paletteNum;
         lzPaletteData = GetMonSpritePalFromSpeciesAndPersonality(species, otId, personality);
-        LoadCompressedPalette(lzPaletteData, 0x100 | paletteNum * 16, 32);
+        LoadHueShiftedMonPalette(lzPaletteData, 0x100 | paletteNum * 16, 32, personality);
         DestroyTask(taskId);
     }
 }

--- a/src/pokemon_jump.c
+++ b/src/pokemon_jump.c
@@ -2736,7 +2736,7 @@ static void CreateJumpMonSprite(struct PokemonJumpGfx *jumpGfx, struct PokemonJu
 
         spritePalette.data = GetMonSpritePalFromSpeciesAndPersonality(monInfo->species, monInfo->otId, monInfo->personality);
         spritePalette.tag = multiplayerId;
-        LoadCompressedSpritePalette(&spritePalette);
+        LoadHueShiftedMonSpritePalette(&spritePalette, monInfo->personality);
 
         Free(buffer);
         Free(unusedBuffer);

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -3991,6 +3991,7 @@ static void LoadDisplayMonGfx(u16 species, u32 pid)
     {
         LoadSpecialPokePic(&gMonFrontPicTable[species], sStorage->tileBuffer, species, pid, TRUE);
         LZ77UnCompWram(sStorage->displayMonPalette, sStorage->displayMonPalBuffer);
+        HueShiftMonPalette((u16*) sStorage->displayMonPalBuffer, sStorage->displayMonPersonality);
         CpuCopy32(sStorage->tileBuffer, sStorage->displayMonTilePtr, MON_PIC_SIZE);
         LoadPalette(sStorage->displayMonPalBuffer, sStorage->displayMonPalOffset, 0x20);
         sStorage->displayMonSprite->invisible = FALSE;

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -4095,7 +4095,7 @@ static u8 LoadMonGfxAndSprite(struct Pokemon *mon, s16 *state)
         return 0xFF;
     case 1:
         pal = GetMonSpritePalStructFromOtIdPersonality(summary->species2, summary->OTID, summary->pid);
-        LoadCompressedSpritePalette(pal);
+        LoadHueShiftedMonSpritePalette(pal, summary->pid);
         SetMultiuseSpriteTemplateToPokemon(pal->tag, 1);
         (*state)++;
         return 0xFF;

--- a/src/pokenav_conditions_1.c
+++ b/src/pokenav_conditions_1.c
@@ -4,6 +4,7 @@
 #include "main.h"
 #include "menu_specialized.h"
 #include "mon_markings.h"
+#include "palette.h"
 #include "pokenav.h"
 #include "pokemon.h"
 #include "pokemon_storage_system.h"
@@ -531,6 +532,7 @@ void ConditionGraphDrawMonPic(s16 index, u8 arg1)
     personality = GetBoxOrPartyMonData(boxId, monId, MON_DATA_PERSONALITY, NULL);
     LoadSpecialPokePic(&gMonFrontPicTable[species], structPtr->monPicGfx[arg1], species, personality, TRUE);
     LZ77UnCompWram(GetMonSpritePalFromSpeciesAndPersonality(species, tid, personality), structPtr->monPal[arg1]);
+    HueShiftMonPalette((u16*) structPtr->monPal[arg1], personality);
 }
 
 u16 GetMonListCount(void)

--- a/src/trainer_pokemon_sprites.c
+++ b/src/trainer_pokemon_sprites.c
@@ -92,12 +92,12 @@ static void LoadPicPaletteByTagOrSlot(u16 species, u32 otId, u32 personality, u8
         if (paletteTag == 0xFFFF)
         {
             sCreatingSpriteTemplate.paletteTag = 0xFFFF;
-            LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, otId, personality), 0x100 + paletteSlot * 0x10, 0x20);
+            LoadHueShiftedMonPalette(GetMonSpritePalFromSpeciesAndPersonality(species, otId, personality), 0x100 + paletteSlot * 0x10, 0x20, personality);
         }
         else
         {
             sCreatingSpriteTemplate.paletteTag = paletteTag;
-            LoadCompressedSpritePalette(GetMonSpritePalStructFromOtIdPersonality(species, otId, personality));
+            LoadHueShiftedMonSpritePalette(GetMonSpritePalStructFromOtIdPersonality(species, otId, personality), personality);
         }
     }
     else
@@ -105,12 +105,12 @@ static void LoadPicPaletteByTagOrSlot(u16 species, u32 otId, u32 personality, u8
         if (paletteTag == 0xFFFF)
         {
             sCreatingSpriteTemplate.paletteTag = 0xFFFF;
-            LoadCompressedPalette(gTrainerFrontPicPaletteTable[species].data, 0x100 + paletteSlot * 0x10, 0x20);
+            LoadHueShiftedMonPalette(gTrainerFrontPicPaletteTable[species].data, 0x100 + paletteSlot * 0x10, 0x20, personality);
         }
         else
         {
             sCreatingSpriteTemplate.paletteTag = paletteTag;
-            LoadCompressedSpritePalette(&gTrainerFrontPicPaletteTable[species]);
+            LoadHueShiftedMonSpritePalette(&gTrainerFrontPicPaletteTable[species], personality);
         }
     }
 }
@@ -118,7 +118,7 @@ static void LoadPicPaletteByTagOrSlot(u16 species, u32 otId, u32 personality, u8
 static void LoadPicPaletteBySlot(u16 species, u32 otId, u32 personality, u8 paletteSlot, bool8 isTrainer)
 {
     if (!isTrainer)
-        LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, otId, personality), paletteSlot * 0x10, 0x20);
+        LoadHueShiftedMonPalette(GetMonSpritePalFromSpeciesAndPersonality(species, otId, personality), paletteSlot * 0x10, 0x20, personality);
     else
         LoadCompressedPalette(gTrainerFrontPicPaletteTable[species].data, paletteSlot * 0x10, 0x20);
 }


### PR DESCRIPTION
## Description
This ports the code portion of the Gen 4 mod "Invidiually-Unique Pokémon Colors (+ Improved Shiny Colors)", which can be found with a more in-depth explanation here:

https://github.com/TheGag96/individual-color-variation

[Example video](https://i.imgur.com/SExrQns.mp4)

Note that not included in this pull request is the second half of the mod, which tries to "fix" a lot of cruddy shiny palettes, especially ones that would be difficult to distinguish from a normal, hue-shifted individual version like Pikachu, Garchomp, Gengar, etc. That could be worked also, but I just haven't attempted it.